### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glottoTrees
 
-Preparation of phylogenetic trees by adapting resources from glottolog.com
+Preparation of phylogenetic trees by adapting resources from [glottolog.org](https://glottolog.org)
 
 ## Guides and explanations
 


### PR DESCRIPTION
Corrected Glottolog URL.

I also think that - since glottoTrees re-distributes the Glottolog data - it should cite Glottolog (probably using the version independent DOI https://doi.org/10.5281/zenodo.596479 ) and include citation of Glottolog in its citation recommendation.